### PR TITLE
Update jenkins file

### DIFF
--- a/pipelines/PIPELINE-FULL-CD/Jenkinsfile
+++ b/pipelines/PIPELINE-FULL-CD/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
                     git checkout -b master origin/master
                     git merge develop
                 """, label: "Merging code to master"
-                sshagent(['github']) {
+                sshagent(['git-credentials-id']){
                     sh "git push origin master"
                 }
 


### PR DESCRIPTION
PIPELINE-FULL-CD: doesn't work, ssh github is not done by this way. We should use ssh jenkins.